### PR TITLE
Allow AWS v4 provider inherited from parent module

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -3,6 +3,6 @@ terraform {
 
   required_providers {
     archive = "~> 1"
-    aws     = "~> 3"
+    aws     = ">= 3, < 5"
   }
 }


### PR DESCRIPTION
https://registry.terraform.io/providers/hashicorp/aws/latest/docs/guides/version-4-upgrade
the upgrade guide shows no version incompatibilities with the v4 provider, and neither does my testing.